### PR TITLE
Add stETH/USD pair to price feed ✨

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -53,9 +53,9 @@ jobs:
         with:
           version: nightly
 
-      - name: Check contracts' interface consistency
-        run: |
-          make check-contracts
+      # - name: Check contracts' interface consistency
+      #   run: |
+      #     make check-contracts
 
       - name: Check formatting
         run: |

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -53,9 +53,9 @@ jobs:
         with:
           version: nightly
 
-      # - name: Check contracts' interface consistency
-      #   run: |
-      #     make check-contracts
+      - name: Check contracts' interface consistency
+        run: |
+          make check-contracts
 
       - name: Check formatting
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN poetry install --without local
 
 FROM base as test
 COPY empiric-package/ /empiric-package
-RUN poetry install --only local
+RUN pip install -e empiric-package
 
 FROM base as production
 ARG EMPIRIC_PACKAGE_VERSION

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ check:
 
 setup:
 	poetry install --no-root
+	pip install -e empiric-package
 
 test: 
 	poetry run pytest tests --log-cli-level=INFO -n logical

--- a/empiric-package/empiric/publisher/assets.py
+++ b/empiric-package/empiric/publisher/assets.py
@@ -32,7 +32,7 @@ EMPIRIC_ALL_ASSETS: List[EmpiricAsset] = [
     {"type": "SPOT", "pair": ("WBTC", "BTC"), "decimals": 8},
     {"type": "SPOT", "pair": ("WBTC", "USD"), "decimals": 8},
     {"type": "SPOT", "pair": ("BTC", "EUR"), "decimals": 8},
-    {"type": "SPOT", "pair": ("ETH", "USD"), "decimals": 8},
+    {"type": "SPOT", "pair": ("ETH", "USD"), "decimals": 18},
     {"type": "SPOT", "pair": ("SOL", "USD"), "decimals": 8},
     {"type": "SPOT", "pair": ("AVAX", "USD"), "decimals": 8},
     {"type": "SPOT", "pair": ("DOGE", "USD"), "decimals": 8},
@@ -49,6 +49,7 @@ EMPIRIC_ALL_ASSETS: List[EmpiricAsset] = [
     {"type": "SPOT", "pair": ("XRP", "USD"), "decimals": 8},
     {"type": "SPOT", "pair": ("MATIC", "USD"), "decimals": 8},
     {"type": "SPOT", "pair": ("AAVE", "USD"), "decimals": 8},
+    {"type": "SPOT", "pair": ("stETH", "USD"), "decimals": 8},
     {"type": "FUTURE", "pair": ("BTC", "USD"), "decimals": 8},
     {"type": "FUTURE", "pair": ("ETH", "USD"), "decimals": 8},
     {

--- a/empiric-package/empiric/publisher/fetchers/coingecko.py
+++ b/empiric-package/empiric/publisher/fetchers/coingecko.py
@@ -31,6 +31,7 @@ ASSET_MAPPING: Dict[str, str] = {
     "XRP": "ripple",
     "MATIC": "matic-network",
     "AAVE": "aave",
+    "stETH": "staked-ether",
 }
 
 
@@ -112,6 +113,7 @@ class CoingeckoFetcher(PublisherInterfaceT):
                 "%Y-%m-%dT%H:%M:%S.%f%z",
             ).timestamp()
         )
+        # volume = int(result["market_data"])
 
         logger.info(f"Fetched price {price} for {pair_id} from Coingecko")
 
@@ -121,4 +123,5 @@ class CoingeckoFetcher(PublisherInterfaceT):
             timestamp=timestamp,
             source=self.SOURCE,
             publisher=self.publisher,
+            volume=0,
         )

--- a/empiric-package/pyproject.toml
+++ b/empiric-package/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Operating System :: OS Independent"
 ]
 packages = [
-  {include = "empiric"},
+  {include = 'empiric' },
   {include = "cli", from = "empiric"},
   {include = "core", from = "empiric"},
   {include = "publisher", from = "empiric"},

--- a/scripts/updates/add_pair.py
+++ b/scripts/updates/add_pair.py
@@ -11,984 +11,493 @@ from empiric.core import Currency, Pair
 ORACLE_ABI = [
     {
         "members": [
-            {
-                "name": "base",
-                "offset": 0,
-                "type": "BaseEntry"
-            },
-            {
-                "name": "key",
-                "offset": 3,
-                "type": "felt"
-            },
-            {
-                "name": "value",
-                "offset": 4,
-                "type": "felt"
-            }
+            {"name": "base", "offset": 0, "type": "BaseEntry"},
+            {"name": "key", "offset": 3, "type": "felt"},
+            {"name": "value", "offset": 4, "type": "felt"},
         ],
         "name": "GenericEntry",
         "size": 5,
-        "type": "struct"
+        "type": "struct",
     },
     {
         "members": [
-            {
-                "name": "timestamp",
-                "offset": 0,
-                "type": "felt"
-            },
-            {
-                "name": "source",
-                "offset": 1,
-                "type": "felt"
-            },
-            {
-                "name": "publisher",
-                "offset": 2,
-                "type": "felt"
-            }
+            {"name": "timestamp", "offset": 0, "type": "felt"},
+            {"name": "source", "offset": 1, "type": "felt"},
+            {"name": "publisher", "offset": 2, "type": "felt"},
         ],
         "name": "BaseEntry",
         "size": 3,
-        "type": "struct"
+        "type": "struct",
     },
     {
         "members": [
-            {
-                "name": "base",
-                "offset": 0,
-                "type": "BaseEntry"
-            },
-            {
-                "name": "pair_id",
-                "offset": 3,
-                "type": "felt"
-            },
-            {
-                "name": "price",
-                "offset": 4,
-                "type": "felt"
-            },
-            {
-                "name": "volume",
-                "offset": 5,
-                "type": "felt"
-            }
+            {"name": "base", "offset": 0, "type": "BaseEntry"},
+            {"name": "pair_id", "offset": 3, "type": "felt"},
+            {"name": "price", "offset": 4, "type": "felt"},
+            {"name": "volume", "offset": 5, "type": "felt"},
         ],
         "name": "SpotEntry",
         "size": 6,
-        "type": "struct"
+        "type": "struct",
     },
     {
         "members": [
-            {
-                "name": "base",
-                "offset": 0,
-                "type": "BaseEntry"
-            },
-            {
-                "name": "pair_id",
-                "offset": 3,
-                "type": "felt"
-            },
-            {
-                "name": "price",
-                "offset": 4,
-                "type": "felt"
-            },
-            {
-                "name": "expiry_timestamp",
-                "offset": 5,
-                "type": "felt"
-            }
+            {"name": "base", "offset": 0, "type": "BaseEntry"},
+            {"name": "pair_id", "offset": 3, "type": "felt"},
+            {"name": "price", "offset": 4, "type": "felt"},
+            {"name": "expiry_timestamp", "offset": 5, "type": "felt"},
         ],
         "name": "FutureEntry",
         "size": 6,
-        "type": "struct"
+        "type": "struct",
     },
     {
         "members": [
-            {
-                "name": "id",
-                "offset": 0,
-                "type": "felt"
-            },
-            {
-                "name": "decimals",
-                "offset": 1,
-                "type": "felt"
-            },
-            {
-                "name": "is_abstract_currency",
-                "offset": 2,
-                "type": "felt"
-            },
-            {
-                "name": "starknet_address",
-                "offset": 3,
-                "type": "felt"
-            },
-            {
-                "name": "ethereum_address",
-                "offset": 4,
-                "type": "felt"
-            }
+            {"name": "id", "offset": 0, "type": "felt"},
+            {"name": "decimals", "offset": 1, "type": "felt"},
+            {"name": "is_abstract_currency", "offset": 2, "type": "felt"},
+            {"name": "starknet_address", "offset": 3, "type": "felt"},
+            {"name": "ethereum_address", "offset": 4, "type": "felt"},
         ],
         "name": "Currency",
         "size": 5,
-        "type": "struct"
+        "type": "struct",
     },
     {
         "members": [
-            {
-                "name": "id",
-                "offset": 0,
-                "type": "felt"
-            },
-            {
-                "name": "quote_currency_id",
-                "offset": 1,
-                "type": "felt"
-            },
-            {
-                "name": "base_currency_id",
-                "offset": 2,
-                "type": "felt"
-            }
+            {"name": "id", "offset": 0, "type": "felt"},
+            {"name": "quote_currency_id", "offset": 1, "type": "felt"},
+            {"name": "base_currency_id", "offset": 2, "type": "felt"},
         ],
         "name": "Pair",
         "size": 3,
-        "type": "struct"
+        "type": "struct",
     },
     {
         "members": [
-            {
-                "name": "timestamp",
-                "offset": 0,
-                "type": "felt"
-            },
-            {
-                "name": "value",
-                "offset": 1,
-                "type": "felt"
-            },
-            {
-                "name": "aggregation_mode",
-                "offset": 2,
-                "type": "felt"
-            },
-            {
-                "name": "num_sources_aggregated",
-                "offset": 3,
-                "type": "felt"
-            }
+            {"name": "timestamp", "offset": 0, "type": "felt"},
+            {"name": "value", "offset": 1, "type": "felt"},
+            {"name": "aggregation_mode", "offset": 2, "type": "felt"},
+            {"name": "num_sources_aggregated", "offset": 3, "type": "felt"},
         ],
         "name": "Checkpoint",
         "size": 4,
-        "type": "struct"
+        "type": "struct",
     },
     {
         "data": [
-            {
-                "name": "old_publisher_registry_address",
-                "type": "felt"
-            },
-            {
-                "name": "new_publisher_registry_address",
-                "type": "felt"
-            }
+            {"name": "old_publisher_registry_address", "type": "felt"},
+            {"name": "new_publisher_registry_address", "type": "felt"},
         ],
         "keys": [],
         "name": "UpdatedPublisherRegistryAddress",
-        "type": "event"
+        "type": "event",
     },
     {
-        "data": [
-            {
-                "name": "new_entry",
-                "type": "GenericEntry"
-            }
-        ],
+        "data": [{"name": "new_entry", "type": "GenericEntry"}],
         "keys": [],
         "name": "SubmittedEntry",
-        "type": "event"
+        "type": "event",
     },
     {
-        "data": [
-            {
-                "name": "new_entry",
-                "type": "SpotEntry"
-            }
-        ],
+        "data": [{"name": "new_entry", "type": "SpotEntry"}],
         "keys": [],
         "name": "SubmittedSpotEntry",
-        "type": "event"
+        "type": "event",
     },
     {
-        "data": [
-            {
-                "name": "new_entry",
-                "type": "FutureEntry"
-            }
-        ],
+        "data": [{"name": "new_entry", "type": "FutureEntry"}],
         "keys": [],
         "name": "SubmittedFutureEntry",
-        "type": "event"
+        "type": "event",
     },
     {
-        "data": [
-            {
-                "name": "currency",
-                "type": "Currency"
-            }
-        ],
+        "data": [{"name": "currency", "type": "Currency"}],
         "keys": [],
         "name": "SubmittedCurrency",
-        "type": "event"
+        "type": "event",
     },
     {
-        "data": [
-            {
-                "name": "currency",
-                "type": "Currency"
-            }
-        ],
+        "data": [{"name": "currency", "type": "Currency"}],
         "keys": [],
         "name": "UpdatedCurrency",
-        "type": "event"
+        "type": "event",
     },
     {
-        "data": [
-            {
-                "name": "pair",
-                "type": "Pair"
-            }
-        ],
+        "data": [{"name": "pair", "type": "Pair"}],
         "keys": [],
         "name": "SubmittedPair",
-        "type": "event"
+        "type": "event",
     },
     {
-        "data": [
-            {
-                "name": "pair_id",
-                "type": "felt"
-            }
-        ],
+        "data": [{"name": "pair_id", "type": "felt"}],
         "keys": [],
         "name": "CheckpointSpotEntry",
-        "type": "event"
+        "type": "event",
     },
     {
-        "data": [
-            {
-                "name": "implementation",
-                "type": "felt"
-            }
-        ],
+        "data": [{"name": "implementation", "type": "felt"}],
         "keys": [],
         "name": "Upgraded",
-        "type": "event"
+        "type": "event",
     },
     {
         "data": [
-            {
-                "name": "previousAdminAddress",
-                "type": "felt"
-            },
-            {
-                "name": "newAdminAddress",
-                "type": "felt"
-            }
+            {"name": "previousAdminAddress", "type": "felt"},
+            {"name": "newAdminAddress", "type": "felt"},
         ],
         "keys": [],
         "name": "AdminAddressChanged",
-        "type": "event"
+        "type": "event",
     },
     {
         "inputs": [
-            {
-                "name": "proxy_admin",
-                "type": "felt"
-            },
-            {
-                "name": "publisher_registry_address",
-                "type": "felt"
-            },
-            {
-                "name": "currencies_len",
-                "type": "felt"
-            },
-            {
-                "name": "currencies",
-                "type": "Currency*"
-            },
-            {
-                "name": "pairs_len",
-                "type": "felt"
-            },
-            {
-                "name": "pairs",
-                "type": "Pair*"
-            }
+            {"name": "proxy_admin", "type": "felt"},
+            {"name": "publisher_registry_address", "type": "felt"},
+            {"name": "currencies_len", "type": "felt"},
+            {"name": "currencies", "type": "Currency*"},
+            {"name": "pairs_len", "type": "felt"},
+            {"name": "pairs", "type": "Pair*"},
         ],
         "name": "initializer",
         "outputs": [],
-        "type": "function"
+        "type": "function",
     },
     {
         "inputs": [
-            {
-                "name": "pair_id",
-                "type": "felt"
-            },
-            {
-                "name": "sources_len",
-                "type": "felt"
-            },
-            {
-                "name": "sources",
-                "type": "felt*"
-            }
+            {"name": "pair_id", "type": "felt"},
+            {"name": "sources_len", "type": "felt"},
+            {"name": "sources", "type": "felt*"},
         ],
         "name": "get_spot_entries_for_sources",
         "outputs": [
-                {
-                    "name": "entries_len",
-                    "type": "felt"
-                },
-            {
-                    "name": "entries",
-                    "type": "SpotEntry*"
-                }
+            {"name": "entries_len", "type": "felt"},
+            {"name": "entries", "type": "SpotEntry*"},
         ],
         "stateMutability": "view",
-        "type": "function"
+        "type": "function",
     },
     {
-        "inputs": [
-            {
-                "name": "pair_id",
-                "type": "felt"
-            }
-        ],
+        "inputs": [{"name": "pair_id", "type": "felt"}],
         "name": "get_spot_entries",
         "outputs": [
-                {
-                    "name": "entries_len",
-                    "type": "felt"
-                },
-            {
-                    "name": "entries",
-                    "type": "SpotEntry*"
-                }
+            {"name": "entries_len", "type": "felt"},
+            {"name": "entries", "type": "SpotEntry*"},
         ],
         "stateMutability": "view",
-        "type": "function"
+        "type": "function",
     },
     {
         "inputs": [
-            {
-                "name": "pair_id",
-                "type": "felt"
-            },
-            {
-                "name": "source",
-                "type": "felt"
-            }
+            {"name": "pair_id", "type": "felt"},
+            {"name": "source", "type": "felt"},
         ],
         "name": "get_spot_entry",
-        "outputs": [
-                {
-                    "name": "entry",
-                    "type": "SpotEntry"
-                }
-        ],
+        "outputs": [{"name": "entry", "type": "SpotEntry"}],
         "stateMutability": "view",
-        "type": "function"
+        "type": "function",
     },
     {
         "inputs": [
-            {
-                "name": "pair_id",
-                "type": "felt"
-            },
-            {
-                "name": "expiry_timestamp",
-                "type": "felt"
-            },
-            {
-                "name": "source",
-                "type": "felt"
-            }
+            {"name": "pair_id", "type": "felt"},
+            {"name": "expiry_timestamp", "type": "felt"},
+            {"name": "source", "type": "felt"},
         ],
         "name": "get_future_entry",
-        "outputs": [
-                {
-                    "name": "entry",
-                    "type": "FutureEntry"
-                }
-        ],
+        "outputs": [{"name": "entry", "type": "FutureEntry"}],
         "stateMutability": "view",
-        "type": "function"
+        "type": "function",
     },
     {
-        "inputs": [
-            {
-                "name": "pair_id",
-                "type": "felt"
-            }
-        ],
+        "inputs": [{"name": "pair_id", "type": "felt"}],
         "name": "get_spot_median",
         "outputs": [
-                {
-                    "name": "price",
-                    "type": "felt"
-                },
-            {
-                    "name": "decimals",
-                    "type": "felt"
-                },
-            {
-                    "name": "last_updated_timestamp",
-                    "type": "felt"
-                },
-            {
-                    "name": "num_sources_aggregated",
-                    "type": "felt"
-                }
+            {"name": "price", "type": "felt"},
+            {"name": "decimals", "type": "felt"},
+            {"name": "last_updated_timestamp", "type": "felt"},
+            {"name": "num_sources_aggregated", "type": "felt"},
         ],
         "stateMutability": "view",
-        "type": "function"
+        "type": "function",
     },
     {
         "inputs": [
-            {
-                "name": "pair_id",
-                "type": "felt"
-            },
-            {
-                "name": "sources_len",
-                "type": "felt"
-            },
-            {
-                "name": "sources",
-                "type": "felt*"
-            }
+            {"name": "pair_id", "type": "felt"},
+            {"name": "sources_len", "type": "felt"},
+            {"name": "sources", "type": "felt*"},
         ],
         "name": "get_spot_median_for_sources",
         "outputs": [
-                {
-                    "name": "price",
-                    "type": "felt"
-                },
-            {
-                    "name": "decimals",
-                    "type": "felt"
-                },
-            {
-                    "name": "last_updated_timestamp",
-                    "type": "felt"
-                },
-            {
-                    "name": "num_sources_aggregated",
-                    "type": "felt"
-                }
+            {"name": "price", "type": "felt"},
+            {"name": "decimals", "type": "felt"},
+            {"name": "last_updated_timestamp", "type": "felt"},
+            {"name": "num_sources_aggregated", "type": "felt"},
         ],
         "stateMutability": "view",
-        "type": "function"
+        "type": "function",
     },
     {
         "inputs": [
-            {
-                "name": "pair_id",
-                "type": "felt"
-            },
-            {
-                "name": "aggregation_mode",
-                "type": "felt"
-            }
+            {"name": "pair_id", "type": "felt"},
+            {"name": "aggregation_mode", "type": "felt"},
         ],
         "name": "get_spot",
         "outputs": [
-                {
-                    "name": "price",
-                    "type": "felt"
-                },
-            {
-                    "name": "decimals",
-                    "type": "felt"
-                },
-            {
-                    "name": "last_updated_timestamp",
-                    "type": "felt"
-                },
-            {
-                    "name": "num_sources_aggregated",
-                    "type": "felt"
-                }
+            {"name": "price", "type": "felt"},
+            {"name": "decimals", "type": "felt"},
+            {"name": "last_updated_timestamp", "type": "felt"},
+            {"name": "num_sources_aggregated", "type": "felt"},
         ],
         "stateMutability": "view",
-        "type": "function"
+        "type": "function",
     },
     {
         "inputs": [
-            {
-                "name": "pair_id",
-                "type": "felt"
-            },
-            {
-                "name": "aggregation_mode",
-                "type": "felt"
-            },
-            {
-                "name": "sources_len",
-                "type": "felt"
-            },
-            {
-                "name": "sources",
-                "type": "felt*"
-            }
+            {"name": "pair_id", "type": "felt"},
+            {"name": "aggregation_mode", "type": "felt"},
+            {"name": "sources_len", "type": "felt"},
+            {"name": "sources", "type": "felt*"},
         ],
         "name": "get_spot_for_sources",
         "outputs": [
-                {
-                    "name": "price",
-                    "type": "felt"
-                },
-            {
-                    "name": "decimals",
-                    "type": "felt"
-                },
-            {
-                    "name": "last_updated_timestamp",
-                    "type": "felt"
-                },
-            {
-                    "name": "num_sources_aggregated",
-                    "type": "felt"
-                }
+            {"name": "price", "type": "felt"},
+            {"name": "decimals", "type": "felt"},
+            {"name": "last_updated_timestamp", "type": "felt"},
+            {"name": "num_sources_aggregated", "type": "felt"},
         ],
         "stateMutability": "view",
-        "type": "function"
+        "type": "function",
     },
     {
         "inputs": [],
         "name": "get_publisher_registry_address",
-        "outputs": [
-                {
-                    "name": "publisher_registry_address",
-                    "type": "felt"
-                }
-        ],
+        "outputs": [{"name": "publisher_registry_address", "type": "felt"}],
         "stateMutability": "view",
-        "type": "function"
+        "type": "function",
     },
     {
-        "inputs": [
-            {
-                "name": "pair_id",
-                "type": "felt"
-            }
-        ],
+        "inputs": [{"name": "pair_id", "type": "felt"}],
         "name": "get_spot_decimals",
-        "outputs": [
-                {
-                    "name": "decimals",
-                    "type": "felt"
-                }
-        ],
+        "outputs": [{"name": "decimals", "type": "felt"}],
         "stateMutability": "view",
-        "type": "function"
+        "type": "function",
     },
     {
-        "inputs": [
-            {
-                "name": "key",
-                "type": "felt"
-            }
-        ],
+        "inputs": [{"name": "key", "type": "felt"}],
         "name": "get_value",
         "outputs": [
-                {
-                    "name": "value",
-                    "type": "felt"
-                },
-            {
-                    "name": "decimals",
-                    "type": "felt"
-                },
-            {
-                    "name": "last_updated_timestamp",
-                    "type": "felt"
-                },
-            {
-                    "name": "num_sources_aggregated",
-                    "type": "felt"
-                }
+            {"name": "value", "type": "felt"},
+            {"name": "decimals", "type": "felt"},
+            {"name": "last_updated_timestamp", "type": "felt"},
+            {"name": "num_sources_aggregated", "type": "felt"},
         ],
         "stateMutability": "view",
-        "type": "function"
+        "type": "function",
     },
     {
         "inputs": [
-            {
-                "name": "base_currency_id",
-                "type": "felt"
-            },
-            {
-                "name": "quote_currency_id",
-                "type": "felt"
-            },
-            {
-                "name": "aggregation_mode",
-                "type": "felt"
-            }
+            {"name": "base_currency_id", "type": "felt"},
+            {"name": "quote_currency_id", "type": "felt"},
+            {"name": "aggregation_mode", "type": "felt"},
         ],
         "name": "get_spot_with_USD_hop",
         "outputs": [
-                {
-                    "name": "price",
-                    "type": "felt"
-                },
-            {
-                    "name": "decimals",
-                    "type": "felt"
-                },
-            {
-                    "name": "last_updated_timestamp",
-                    "type": "felt"
-                },
-            {
-                    "name": "num_sources_aggregated",
-                    "type": "felt"
-                }
+            {"name": "price", "type": "felt"},
+            {"name": "decimals", "type": "felt"},
+            {"name": "last_updated_timestamp", "type": "felt"},
+            {"name": "num_sources_aggregated", "type": "felt"},
         ],
         "stateMutability": "view",
-        "type": "function"
+        "type": "function",
     },
     {
-        "inputs": [
-            {
-                "name": "new_entry",
-                "type": "FutureEntry"
-            }
-        ],
+        "inputs": [{"name": "new_entry", "type": "FutureEntry"}],
         "name": "publish_future_entry",
         "outputs": [],
-        "type": "function"
+        "type": "function",
     },
     {
-        "inputs": [
-            {
-                "name": "new_entry",
-                "type": "SpotEntry"
-            }
-        ],
+        "inputs": [{"name": "new_entry", "type": "SpotEntry"}],
         "name": "publish_spot_entry",
         "outputs": [],
-        "type": "function"
+        "type": "function",
     },
     {
-        "inputs": [
-            {
-                "name": "new_entry",
-                "type": "GenericEntry"
-            }
-        ],
+        "inputs": [{"name": "new_entry", "type": "GenericEntry"}],
         "name": "publish_entry",
         "outputs": [],
-        "type": "function"
+        "type": "function",
     },
     {
         "inputs": [
-            {
-                "name": "new_entries_len",
-                "type": "felt"
-            },
-            {
-                "name": "new_entries",
-                "type": "GenericEntry*"
-            }
+            {"name": "new_entries_len", "type": "felt"},
+            {"name": "new_entries", "type": "GenericEntry*"},
         ],
         "name": "publish_entries",
         "outputs": [],
-        "type": "function"
+        "type": "function",
     },
     {
         "inputs": [
-            {
-                "name": "new_entries_len",
-                "type": "felt"
-            },
-            {
-                "name": "new_entries",
-                "type": "FutureEntry*"
-            }
+            {"name": "new_entries_len", "type": "felt"},
+            {"name": "new_entries", "type": "FutureEntry*"},
         ],
         "name": "publish_future_entries",
         "outputs": [],
-        "type": "function"
+        "type": "function",
     },
     {
         "inputs": [
-            {
-                "name": "new_entries_len",
-                "type": "felt"
-            },
-            {
-                "name": "new_entries",
-                "type": "SpotEntry*"
-            }
+            {"name": "new_entries_len", "type": "felt"},
+            {"name": "new_entries", "type": "SpotEntry*"},
         ],
         "name": "publish_spot_entries",
         "outputs": [],
-        "type": "function"
+        "type": "function",
     },
     {
-        "inputs": [
-            {
-                "name": "publisher_registry_address",
-                "type": "felt"
-            }
-        ],
+        "inputs": [{"name": "publisher_registry_address", "type": "felt"}],
         "name": "update_publisher_registry_address",
         "outputs": [],
-        "type": "function"
+        "type": "function",
     },
     {
-        "inputs": [
-            {
-                "name": "currency",
-                "type": "Currency"
-            }
-        ],
+        "inputs": [{"name": "currency", "type": "Currency"}],
         "name": "add_currency",
         "outputs": [],
-        "type": "function"
+        "type": "function",
     },
     {
-        "inputs": [
-            {
-                "name": "currency",
-                "type": "Currency"
-            }
-        ],
+        "inputs": [{"name": "currency", "type": "Currency"}],
         "name": "update_currency",
         "outputs": [],
-        "type": "function"
+        "type": "function",
     },
     {
-        "inputs": [
-            {
-                "name": "pair",
-                "type": "Pair"
-            }
-        ],
+        "inputs": [{"name": "pair", "type": "Pair"}],
         "name": "add_pair",
         "outputs": [],
-        "type": "function"
+        "type": "function",
     },
     {
-        "inputs": [
-            {
-                "name": "key",
-                "type": "felt"
-            }
-        ],
+        "inputs": [{"name": "key", "type": "felt"}],
         "name": "get_latest_checkpoint_index",
-        "outputs": [
-                {
-                    "name": "latest",
-                    "type": "felt"
-                }
-        ],
+        "outputs": [{"name": "latest", "type": "felt"}],
         "stateMutability": "view",
-        "type": "function"
+        "type": "function",
     },
     {
-        "inputs": [
-            {
-                "name": "key",
-                "type": "felt"
-            },
-            {
-                "name": "index",
-                "type": "felt"
-            }
-        ],
+        "inputs": [{"name": "key", "type": "felt"}, {"name": "index", "type": "felt"}],
         "name": "get_checkpoint",
-        "outputs": [
-                {
-                    "name": "checkpoint",
-                    "type": "Checkpoint"
-                }
-        ],
+        "outputs": [{"name": "checkpoint", "type": "Checkpoint"}],
         "stateMutability": "view",
-        "type": "function"
+        "type": "function",
     },
     {
         "inputs": [],
         "name": "get_sources_threshold",
-        "outputs": [
-                {
-                    "name": "threshold",
-                    "type": "felt"
-                }
-        ],
+        "outputs": [{"name": "threshold", "type": "felt"}],
         "stateMutability": "view",
-        "type": "function"
+        "type": "function",
     },
     {
-        "inputs": [
-            {
-                "name": "new_implementation",
-                "type": "felt"
-            }
-        ],
+        "inputs": [{"name": "new_implementation", "type": "felt"}],
         "name": "upgrade",
         "outputs": [],
-        "type": "function"
+        "type": "function",
     },
     {
-        "inputs": [
-            {
-                "name": "new_admin_address",
-                "type": "felt"
-            }
-        ],
+        "inputs": [{"name": "new_admin_address", "type": "felt"}],
         "name": "set_admin_address",
         "outputs": [],
-        "type": "function"
+        "type": "function",
     },
     {
         "inputs": [],
         "name": "get_implementation_hash",
-        "outputs": [
-                {
-                    "name": "address",
-                    "type": "felt"
-                }
-        ],
+        "outputs": [{"name": "address", "type": "felt"}],
         "stateMutability": "view",
-        "type": "function"
+        "type": "function",
     },
     {
         "inputs": [],
         "name": "get_admin_address",
-        "outputs": [
-                {
-                    "name": "admin_address",
-                    "type": "felt"
-                }
-        ],
+        "outputs": [{"name": "admin_address", "type": "felt"}],
         "stateMutability": "view",
-        "type": "function"
+        "type": "function",
     },
     {
         "inputs": [
-            {
-                "name": "pair_id",
-                "type": "felt"
-            },
-            {
-                "name": "aggregation_mode",
-                "type": "felt"
-            }
+            {"name": "pair_id", "type": "felt"},
+            {"name": "aggregation_mode", "type": "felt"},
         ],
         "name": "set_checkpoint",
         "outputs": [],
-        "type": "function"
+        "type": "function",
     },
     {
         "inputs": [
-            {
-                "name": "pair_ids_len",
-                "type": "felt"
-            },
-            {
-                "name": "pair_ids",
-                "type": "felt*"
-            },
-            {
-                "name": "aggregation_mode",
-                "type": "felt"
-            }
+            {"name": "pair_ids_len", "type": "felt"},
+            {"name": "pair_ids", "type": "felt*"},
+            {"name": "aggregation_mode", "type": "felt"},
         ],
         "name": "set_checkpoints",
         "outputs": [],
-        "type": "function"
+        "type": "function",
     },
     {
         "inputs": [
-            {
-                "name": "pair_id",
-                "type": "felt"
-            },
-            {
-                "name": "timestamp",
-                "type": "felt"
-            }
+            {"name": "pair_id", "type": "felt"},
+            {"name": "timestamp", "type": "felt"},
         ],
         "name": "get_last_spot_checkpoint_before",
         "outputs": [
-                {
-                    "name": "checkpoint",
-                    "type": "Checkpoint"
-                },
-            {
-                    "name": "idx",
-                    "type": "felt"
-                }
+            {"name": "checkpoint", "type": "Checkpoint"},
+            {"name": "idx", "type": "felt"},
         ],
         "stateMutability": "view",
-        "type": "function"
+        "type": "function",
     },
     {
-        "inputs": [
-            {
-                "name": "threshold",
-                "type": "felt"
-            }
-        ],
+        "inputs": [{"name": "threshold", "type": "felt"}],
         "name": "set_sources_threshold",
         "outputs": [],
-        "type": "function"
-    }
+        "type": "function",
+    },
 ]
 
 admin_contract_address = (
     # 0x029E7D00D0142EB684D6B010DDFE59348D892E5F8FF94F1B77CD372645DF4B77 mainnet
-    0x021d6f33c00d3657d7ec6f9322399729afdf21533b77cf0512ac583b4755f011  # goerli
+    0x021D6F33C00D3657D7EC6F9322399729AFDF21533B77CF0512AC583B4755F011  # goerli
 )
 oracle_proxy_address = (
     # 0x0346c57f094d641ad94e43468628d8e9c574dcb2803ec372576ccc60a40be2c4 mainnet
-    0x446812bac98c08190dee8967180f4e3cdcd1db9373ca269904acb17f67f7093  # goerli
+    0x446812BAC98C08190DEE8967180F4E3CDCD1DB9373CA269904ACB17F67F7093  # goerli
 )
 
 currencies_to_add = [
-    # Currency(
-    #     "WBTC",
-    #     8,
-    #     0,
-    #     0x12d537dc323c439dc65c976fad242d5610d27cfb5f31689a0a319b8be7f3d56,
-    #     0xC04B0d3107736C32e19F1c62b2aF67BE61d63a05,
-    # ),
+    Currency(
+        "stETH",
+        18,
+        0,
+        0,
+        0xAE7AB96520DE3A18E5E111B5EAAB095312D7FE84,
+    ),
 ]
 pairs_to_add = [
     # Pair("WBTC/BTC", "WBTC", "BTC"),
     # Pair("WBTC/USD", "WBTC", "USD"),
+    Pair("stETH/USD", "stETH", "USD"),
 ]
 
-currencies_to_update = [ 
-    Currency(
-        "BTC",
-        8,
-        1,
-        0,
-        0,
-    ),
+currencies_to_update = [
+    # Currency(
+    #     "BTC",
+    #     8,
+    #     1,
+    #     0,
+    #     0,
+    # ),
 ]
 
 NETWORK = "testnet"
@@ -1004,11 +513,7 @@ async def main():
         CHAIN_ID,
     )
 
-    admin = Account(
-        address=admin_contract_address,
-        client=gateway,
-        signer=signer
-    )
+    admin = Account(address=admin_contract_address, client=gateway, signer=signer)
 
     # Create contract instance
     contract = Contract(address=oracle_proxy_address, abi=ORACLE_ABI, provider=admin)
@@ -1016,9 +521,8 @@ async def main():
     # Add Currencies
     for currency in currencies_to_add:
         print(currency.to_dict())
-        invocation = await contract.functions['add_currency'].invoke(
-            currency.to_dict(),
-            max_fee=int(1e16)
+        invocation = await contract.functions["add_currency"].invoke(
+            currency.to_dict(), max_fee=int(1e16)
         )
         print(hex(invocation.hash))
         await invocation.wait_for_acceptance()
@@ -1026,9 +530,8 @@ async def main():
     # Add Pairs
     for pair in pairs_to_add:
         print(pair.to_dict())
-        invocation = await contract.functions['add_pair'].invoke(
-            pair.to_dict(),
-            max_fee=int(1e16)
+        invocation = await contract.functions["add_pair"].invoke(
+            pair.to_dict(), max_fee=int(1e16)
         )
         print(hex(invocation.hash))
         await invocation.wait_for_acceptance()
@@ -1036,12 +539,12 @@ async def main():
     # Update Currencies
     for currency in currencies_to_update:
         print(currency.to_dict())
-        invocation = await contract.functions['update_currency'].invoke(
-            currency.to_dict(),
-            max_fee=int(1e16)
+        invocation = await contract.functions["update_currency"].invoke(
+            currency.to_dict(), max_fee=int(1e16)
         )
         print(hex(invocation.hash))
         await invocation.wait_for_acceptance()
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/stagecoach/integration_tests/coingecko/Dockerfile
+++ b/stagecoach/integration_tests/coingecko/Dockerfile
@@ -1,0 +1,5 @@
+FROM astralylabs/empiric-publisher:test
+
+COPY coingecko_publisher.py .
+
+CMD [ "python", "coingecko_publisher.py" ]

--- a/stagecoach/integration_tests/coingecko/coingecko_publisher.py
+++ b/stagecoach/integration_tests/coingecko/coingecko_publisher.py
@@ -1,0 +1,37 @@
+import asyncio
+import os
+
+from empiric.core.logger import get_stream_logger
+from empiric.core.utils import log_entry
+from empiric.publisher.assets import EMPIRIC_ALL_ASSETS
+from empiric.publisher.client import EmpiricPublisherClient
+from empiric.publisher.fetchers import CoingeckoFetcher
+
+logger = get_stream_logger()
+
+
+async def main():
+    publisher = os.environ.get("PUBLISHER")
+    publisher_private_key = int(os.environ.get("PUBLISHER_PRIVATE_KEY"))
+    publisher_address = int(os.environ.get("PUBLISHER_ADDRESS"))
+
+    publisher_client = EmpiricPublisherClient(
+        account_private_key=publisher_private_key,
+        account_contract_address=publisher_address,
+    )
+    coingecko_fetcher = CoingeckoFetcher(EMPIRIC_ALL_ASSETS, publisher)
+    publisher_client.add_fetcher(coingecko_fetcher)
+    _entries = await publisher_client.fetch()
+    print(_entries)
+
+    # response = await publisher_client.publish_many(_entries, pagination=20)
+    # for res in response:
+    #     logger.info(f"hash: {res.hash}")
+    #     await res.wait_for_acceptance()
+
+    # for entry in _entries:
+    #     log_entry(entry, logger=logger)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
This PR does the following : 
- Adds `stETH` to the list of Empiric Assets.
- Apply minor fixes (makefile, dockerfile, ci..)
- Adds Coingecko integration testing
Note that Coingecko fetcher **SHOULD NOT** be used in any publisher, as it is rate limited and will fail.
- [ ] Adds a new data source that supports `stETH` as all the currently supported ones **DO NOT** have it.
